### PR TITLE
Bugfix documentation build step

### DIFF
--- a/.jazzy.json
+++ b/.jazzy.json
@@ -1,7 +1,7 @@
 {
    "xcodebuild_arguments":[
       "-workspace",
-      "Example/Example.xcworkspace",
+      "Example/Gini.xcworkspace",
       "-scheme",
       "Example"
    ],

--- a/Documentation/scripts/deploy-documentation.sh
+++ b/Documentation/scripts/deploy-documentation.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 /usr/local/bin/jazzy --config .jazzy.json --no-clean
 
 github_user=$1
@@ -10,7 +12,7 @@ git clone -b gh-pages https://"$github_user":"$github_password"@github.com/gini/
 
 rm -rf gh-pages/*
 mkdir gh-pages/docs
-cp -R Api/. gh-pages/docs/
+cp -R api/. gh-pages/docs/
 
 cd gh-pages
 touch .nojekyll


### PR DESCRIPTION
Documentation build step was silently failing so I did the following to fix that:
* Fixed the xcworkspace used to generate the documentation with Jazzy.
* Made the documentation build script to fail if any of the commands fail in order to brake the build.