### PR TITLE
Allow custom api and user service domains

### DIFF
--- a/Example/.swiftlint.yml
+++ b/Example/.swiftlint.yml
@@ -15,7 +15,7 @@ force_cast: warning # implicitly
 force_try:
   severity: warning # explicitly
 line_length:
-- 120 # warning
+- 200 # warning
 - 600 # error
 function_body_length:
 - 50 # warning

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Gini (0.2.0):
-    - Gini/DocumentsAPI (= 0.2.0)
-  - Gini/DocumentsAPI (0.2.0)
-  - Gini/Pinning (0.2.0):
+  - Gini (0.3.0):
+    - Gini/DocumentsAPI (= 0.3.0)
+  - Gini/DocumentsAPI (0.3.0)
+  - Gini/Pinning (0.3.0):
     - Gini/DocumentsAPI
     - TrustKit (~> 1.6)
-  - Gini/Tests (0.2.0)
+  - Gini/Tests (0.3.0)
   - TrustKit (1.6.2)
 
 DEPENDENCIES:
@@ -23,9 +23,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Gini: 10eb333c01cf4a95d6f5535e8702c91d65f5e0eb
+  Gini: fbc0443ec77c14ce8b4cd2e309e2513252b5d5ce
   TrustKit: 0a64b37d31518f16e344ceaf27e129dde624ce75
 
 PODFILE CHECKSUM: 9142371538be20471536f26b1322049c5c03bde0
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.9.1

--- a/Gini.podspec
+++ b/Gini.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Gini"
-  spec.version      = "0.2.0"
+  spec.version      = "0.3.0"
   spec.summary      = "Gini library for scanning documents"
   spec.description  = <<-DESC
   Gini provides an information extraction system for analyzing documents (e. g. invoices or

--- a/Gini/Classes/Documents/APIResource.swift
+++ b/Gini/Classes/Documents/APIResource.swift
@@ -14,13 +14,16 @@ public enum APIDomain {
     case accounting
     /// The GYM API, which points to https://gym.gini.net/
     case gym(tokenSource: AlternativeTokenSource)
+    /// A custom domain
+    case custom(domain: String)
     
     var domainString: String {
         
         switch self {
-        case .default: return "api"
-        case .accounting: return "accounting-api"
-        case .gym: return "gym"
+        case .default: return "api.gini.net"
+        case .accounting: return "accounting-api.gini.net"
+        case .gym: return "gym.gini.net"
+        case .custom(let domain): return domain
         }
     }
 }
@@ -36,7 +39,7 @@ struct APIResource<T: Decodable>: Resource {
     var authServiceType: AuthServiceType? = .apiService
     
     var host: String {
-        return "\(domain.domainString).gini.net"
+        return "\(domain.domainString)"
     }
     
     var scheme: URLScheme {
@@ -45,7 +48,7 @@ struct APIResource<T: Decodable>: Resource {
     
     var apiVersion: Int {
         switch domain {
-        case .default, .gym: return 2
+        case .default, .gym, .custom: return 2
         case .accounting: return 1
         }
     }

--- a/Gini/Classes/Documents/Core/Auth/SessionManager+Auth.swift
+++ b/Gini/Classes/Documents/Core/Auth/SessionManager+Auth.swift
@@ -85,6 +85,7 @@ fileprivate extension SessionManager {
                 let user = AuthHelper.generateUser(with: domain)
                 
                 let resource = UserResource<String>(method: .users,
+                                                    userDomain: self.userDomain,
                                                     httpMethod: .post,
                                                     body: try? JSONEncoder().encode(user))
 
@@ -119,13 +120,18 @@ fileprivate extension SessionManager {
             .addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)?
             .data(using: .utf8)
         
-        let resource = UserResource<Token>(method: .token(grantType: .password), httpMethod: .post, body: body)
+        let resource = UserResource<Token>(method: .token(grantType: .password),
+                                           userDomain: self.userDomain,
+                                           httpMethod: .post,
+                                           body: body)
         
         data(resource: resource, completion: completion)
     }
     
     func fetchClientAccessToken(completion: @escaping CompletionResult<Void>) {
-        let resource = UserResource<Token>(method: .token(grantType: .clientCredentials), httpMethod: .get)
+        let resource = UserResource<Token>(method: .token(grantType: .clientCredentials),
+                                           userDomain: self.userDomain,
+                                           httpMethod: .get)
         data(resource: resource) { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/Gini/Classes/Documents/Core/Auth/UserResource.swift
+++ b/Gini/Classes/Documents/Core/Auth/UserResource.swift
@@ -7,12 +7,29 @@
 
 import Foundation
 
+public enum UserDomain {
+    /// The default one, which points to https://user.gini.net
+    case `default`
+    /// A custom domain
+    case custom(domain: String)
+    
+    var domainString: String {
+        
+        switch self {
+        case .default: return "user.gini.net"
+        case .custom(let domain): return domain
+        }
+    }
+}
+
 struct UserResource<T: Decodable>: Resource {    
     typealias ResourceMethodType = UserMethod
     typealias ResponseType = T
     
+    var domain: UserDomain
+    
     var host: String {
-        return "user.gini.net"
+        return "\(domain.domainString)"
     }
     
     var scheme: URLScheme {
@@ -60,8 +77,13 @@ struct UserResource<T: Decodable>: Resource {
         }
     }
 
-    init(method: UserMethod, httpMethod: HTTPMethod, additionalHeaders: HTTPHeaders = [:], body: Data? = nil) {
+    init(method: UserMethod,
+         userDomain: UserDomain,
+         httpMethod: HTTPMethod,
+         additionalHeaders: HTTPHeaders = [:],
+         body: Data? = nil) {
         self.method = method
+        self.domain = userDomain
         self.params = RequestParameters(method: httpMethod,
                                         body: body)
         self.params.headers = defaultHeaders.merging(additionalHeaders) { (current, _ ) in current }

--- a/Gini/Classes/Documents/Core/GiniSDK.swift
+++ b/Gini/Classes/Documents/Core/GiniSDK.swift
@@ -49,18 +49,24 @@ extension GiniSDK {
     public struct Builder {
         var client: Client
         var api: APIDomain = .default
+        var userApi: UserDomain = .default
         var logLevel: LogLevel
         
         /**
          *  Creates a Gini SDK
          *
          * - Parameter client:            The Gini API client credentials
-         * - Parameter api:               The Gini API that the sdk interacts to. `APIDomain.default` by default
+         * - Parameter api:               The Gini API that the sdk interacts with. `APIDomain.default` by default
+         * - Parameter userApi:           The Gini User API that the sdk interacts with. `UserDomain.default` by default
          * - Parameter logLevel:          The log level. `LogLevel.none` by default.
          */
-        public init(client: Client, api: APIDomain = .default, logLevel: LogLevel = .none) {
+        public init(client: Client,
+                    api: APIDomain = .default,
+                    userApi: UserDomain = .default,
+                    logLevel: LogLevel = .none) {
             self.client = client
             self.api = api
+            self.userApi = userApi
             self.logLevel = logLevel
         }
 
@@ -74,9 +80,12 @@ extension GiniSDK {
             // Initialize GiniSDK
             switch api {
             case .accounting:
-                return GiniSDK(documentService: AccountingDocumentService(sessionManager: SessionManager()))
+                return GiniSDK(documentService: AccountingDocumentService(sessionManager: SessionManager(userDomain: userApi)))
             case .default:
-                return GiniSDK(documentService: DefaultDocumentService(sessionManager: SessionManager()))
+                return GiniSDK(documentService: DefaultDocumentService(sessionManager: SessionManager(userDomain: userApi)))
+            case .custom:
+                return GiniSDK(documentService: DefaultDocumentService(sessionManager: SessionManager(userDomain: userApi),
+                                                                       apiDomain: api))
             case .gym(let tokenSource):
                 return GiniSDK(documentService: DefaultDocumentService(sessionManager:
                     SessionManager(alternativeTokenSource: tokenSource)))

--- a/Gini/Classes/Documents/Core/SessionManager.swift
+++ b/Gini/Classes/Documents/Core/SessionManager.swift
@@ -59,6 +59,7 @@ final class SessionManager: NSObject {
     let keyStore: KeyStore
     let alternativeTokenSource: AlternativeTokenSource?
     private let session: URLSession
+    let userDomain: UserDomain
     
     enum TaskType {
         case data, download, upload(Data)
@@ -66,7 +67,8 @@ final class SessionManager: NSObject {
     
     init(keyStore: KeyStore = KeychainStore(),
          alternativeTokenSource: AlternativeTokenSource? = nil,
-         urlSession: URLSession = .init(configuration: .default)) {
+         urlSession: URLSession = .init(configuration: .default),
+         userDomain: UserDomain = .default) {
         
         self.keyStore = keyStore
         self.alternativeTokenSource = alternativeTokenSource
@@ -74,6 +76,7 @@ final class SessionManager: NSObject {
         #if PINNING_AVAILABLE
         self.session.delegate = self
         #endif
+        self.userDomain = userDomain
     }
 }
 

--- a/Gini/Classes/Documents/DefaultDocumentService.swift
+++ b/Gini/Classes/Documents/DefaultDocumentService.swift
@@ -9,16 +9,16 @@ import Foundation
 
 typealias DefaultDocumentServiceProtocol = DocumentService & V2DocumentService
 
-/// The default document service. Interacts with the `APIDomain.default` api.
+/// The default document service. By default interacts with the `APIDomain.default` api.
 public final class DefaultDocumentService: DefaultDocumentServiceProtocol {
     
-    fileprivate let sessionManager: SessionManagerProtocol
+    let sessionManager: SessionManagerProtocol
     
-    /// The default API domain
-    public var apiDomain: APIDomain = .default
+    public var apiDomain: APIDomain
     
-    init(sessionManager: SessionManagerProtocol) {
+    init(sessionManager: SessionManagerProtocol, apiDomain: APIDomain = .default) {
         self.sessionManager = sessionManager
+        self.apiDomain = apiDomain
     }
     
     /**

--- a/Gini/Tests/Classes/APIResourceTests.swift
+++ b/Gini/Tests/Classes/APIResourceTests.swift
@@ -252,4 +252,13 @@ final class APIResourceTests: XCTestCase {
                        "path should match")
     }
     
+    func testCustomApiDomain() {
+        let resource = APIResource<[Document]>(method: .documents(limit: nil, offset: nil),
+                                               apiDomain: .custom(domain: "custom.domain.com"),
+                                               httpMethod: .get)
+        
+        let urlString = resource.url.absoluteString
+        XCTAssertEqual(urlString, "https://custom.domain.com/documents/", "path should match")
+    }
+    
 }

--- a/Gini/Tests/Classes/GiniSDKTests.swift
+++ b/Gini/Tests/Classes/GiniSDKTests.swift
@@ -8,6 +8,8 @@
 import XCTest
 @testable import Gini
 
+// swiftlint:disable force_cast
+
 final class GiniSDKTests: XCTestCase {
     
     func testBuildWithCustomApiDomain() {

--- a/Gini/Tests/Classes/GiniSDKTests.swift
+++ b/Gini/Tests/Classes/GiniSDKTests.swift
@@ -1,0 +1,47 @@
+//
+//  GiniSDKTests.swift
+//  Gini-Unit-Tests
+//
+//  Created by Alpár Szotyori on 03.04.20.
+//
+
+import XCTest
+@testable import Gini
+
+final class GiniSDKTests: XCTestCase {
+    
+    func testBuildWithCustomApiDomain() {
+        let giniSdk = GiniSDK.Builder(client: Client(id: "", secret: "", domain: ""),
+                                      api: .custom(domain: "custom-api.domain.com"),
+                                      logLevel: .none)
+            .build()
+        
+        let documentService: DefaultDocumentService = giniSdk.documentService()
+        XCTAssertEqual(documentService.apiDomain.domainString, "custom-api.domain.com")
+    }
+    
+    func testBuildWithCustomUserDomain() {
+        let giniSdk = GiniSDK.Builder(client: Client(id: "", secret: "", domain: ""),
+                                      userApi: .custom(domain: "custom-user.domain.com"),
+                                      logLevel: .none)
+            .build()
+        
+        let documentService: DefaultDocumentService = giniSdk.documentService()
+        let sessionManager: SessionManager = documentService.sessionManager as! SessionManager
+        XCTAssertEqual(sessionManager.userDomain.domainString, "custom-user.domain.com")
+    }
+    
+    func testBuildWithCustomApiAndUserDomain() {
+        let giniSdk = GiniSDK.Builder(client: Client(id: "", secret: "", domain: ""),
+                                      api: .custom(domain: "custom-api.domain.com"),
+                                      userApi: .custom(domain: "custom-user.domain.com"),
+                                      logLevel: .none)
+            .build()
+        
+        let documentService: DefaultDocumentService = giniSdk.documentService()
+        XCTAssertEqual(documentService.apiDomain.domainString, "custom-api.domain.com")
+        
+        let sessionManager: SessionManager = documentService.sessionManager as! SessionManager
+        XCTAssertEqual(sessionManager.userDomain.domainString, "custom-user.domain.com")
+    }
+}

--- a/Gini/Tests/Classes/UserResourceTests.swift
+++ b/Gini/Tests/Classes/UserResourceTests.swift
@@ -16,21 +16,35 @@ class UserResourceTests: XCTestCase {
                                               headers: ["Accept": "application/vnd.gini.v1+json"])
     
     func testTokenResourceWithClientCredentials() {
-        let resource = UserResource<Token>(method: .token(grantType: .clientCredentials), httpMethod: .get)
+        let resource = UserResource<Token>(method: .token(grantType: .clientCredentials),
+                                           userDomain: .default,
+                                           httpMethod: .get)
         let urlString: String = resource.url.absoluteString
         XCTAssertEqual(urlString, baseUserCenterAPIURLString + "/oauth/token?grant_type=client_credentials")
     }
     
     func testTokenResourceWithPassword() {
-        let resource = UserResource<Token>(method: .token(grantType: .password), httpMethod: .get)
+        let resource = UserResource<Token>(method: .token(grantType: .password),
+                                           userDomain: .default,
+                                           httpMethod: .get)
         let urlString: String = resource.url.absoluteString
         XCTAssertEqual(urlString, baseUserCenterAPIURLString + "/oauth/token?grant_type=password")
     }
     
     func testUsersResource() {
-        let resource = UserResource<Token>(method: .users, httpMethod: .post)
+        let resource = UserResource<Token>(method: .users,
+                                           userDomain: .default,
+                                           httpMethod: .post)
         let urlString = resource.url.absoluteString
         XCTAssertEqual(urlString, baseUserCenterAPIURLString + "/api/users")
+    }
+    
+    func testCustomUserDomain() {
+        let resource = UserResource<Token>(method: .users,
+                                           userDomain: .custom(domain: "custom.domain.com"),
+                                           httpMethod: .post)
+        let urlString = resource.url.absoluteString
+        XCTAssertEqual(urlString, "https://custom.domain.com/api/users")
     }
     
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,12 +19,12 @@ pipeline {
     }
     stage('Build') {
       steps {
-        sh 'xcodebuild -workspace Example/Gini.xcworkspace -scheme "Example" -destination \'platform=iOS Simulator,name=iPhone XS\''
+        sh 'xcodebuild -workspace Example/Gini.xcworkspace -scheme "Example" -destination \'platform=iOS Simulator,name=iPhone 11\''
       }
     }
     stage('Unit tests') {
       steps {
-        sh 'xcodebuild test -workspace Example/Gini.xcworkspace -scheme "Gini-Unit-Tests" -destination \'platform=iOS Simulator,name=iPhone XS\''
+        sh 'xcodebuild test -workspace Example/Gini.xcworkspace -scheme "Gini-Unit-Tests" -destination \'platform=iOS Simulator,name=iPhone 11\''
       }
     }
     stage('Documentation') {


### PR DESCRIPTION
This feature is available in the Android version and is needed for using proxies. This feature is also useful for clients using certificate pinning to try out the upcoming certificate with special transparent proxies which already use the new certificate.

**Warning:** I set `master` as the target branch so that we can release this before the line items feature, but feel free to change this.

### Ticket
[PIA-604](https://ginis.atlassian.net/browse/PIA-604)