### PR TITLE
Support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ Carthage
 #
 
 Pods/
+
+# Swift Package Manager
+.swiftpm
+Package.resolved

--- a/Documentation/source/Installation.md
+++ b/Documentation/source/Installation.md
@@ -1,7 +1,7 @@
 Installation
 =============================
 
-Gini iOS library can either be installed by using CocoaPods or by manually dragging the required files to your project.
+Gini iOS library can either be installed by using CocoaPods, Swift Package Manager or by manually dragging the required files to your project.
 
 ## CocoaPods
 
@@ -27,6 +27,20 @@ Then run the following command:
 ```bash
 $ pod install
 ```
+
+## Swift Package manager
+
+[Swift Package Manager](https://swift.org/package-manager/) is preinstalled with Xcode.
+
+To integrate the Gini iOS library within a Swift Package, add the following line to your  Package.swift file:
+
+```Swift
+dependencies: [
+    .package(name: "Gini", url: "https://github.com/gini/gini-ios.git", from: TBD)
+]
+```
+
+To integrate within an Xcode project, please use the Xcode assistant for adding Swift Packages.
 
 ## Manually
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Gini",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "Gini",
+            targets: ["Gini"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/datatheorem/TrustKit", from: "1.6.5")
+    ],
+    targets: [
+        .target(
+            name: "Gini",
+            dependencies: ["TrustKit"],
+            path: "Gini/Classes"),
+        
+        
+        // Unit Tests are currently unsupported using Swift Package Manager due to the lack
+        // of resources support. Hence, the Tests/Assets/.json files cannot be embedded into
+        // the test target, leading to runtime crashes in the tests due to missing resources.
+        // Resources support for SPM has been implemented with SE-0271 and will be released
+        // as part of Swift 5.3.
+        // https://github.com/apple/swift-evolution/blob/master/proposals/0271-package-manager-resources.md
+        
+        /*.testTarget(
+            name: "GiniTests",
+            dependencies: ["Gini"],
+            path: "Gini/Tests"),*/
+    ]
+)


### PR DESCRIPTION
This introduces support for Swift Package manager.

Unit Tests are currently unsupported using Swift Package Manager due to the lack of resources support. Hence, the Tests/Assets/.json files cannot be embedded into the test target, leading to runtime crashes in the tests due to missing resources. Resources support for SPM has been implemented with SE-0271 and will be released as part of Swift 5.3. Until then, I left the test target commented.

https://github.com/apple/swift-evolution/blob/master/proposals/0271-package-manager-resources.md